### PR TITLE
Removed Memory Resource from MemMgr

### DIFF
--- a/starlight/starlight/Engine/Engine.cpp
+++ b/starlight/starlight/Engine/Engine.cpp
@@ -17,8 +17,8 @@ void Engine::Update( /* delta if used variable timing game loop */ )
 template <typename SystemType>
 void Engine::AddSystem()
 {
-	MemoryResource* SystemMemory = MemMgr::Alloc(sizeof(SystemType), MemMgr::AllocatorType::PoolData);
-	AllSystems.push_back(new (SystemMemory->addr) SystemType(this));
+	uint8_t* SystemMemory = MemMgr::Alloc(sizeof(SystemType), MemMgr::AllocatorType::PoolData);
+	AllSystems.push_back(new (SystemMemory) SystemType(this));
 }
 
 Entity* Engine::CreateEntity()
@@ -28,7 +28,7 @@ Entity* Engine::CreateEntity()
 	// -- query the engine or something that has used entity IDs mapped
 
 	static EntityID NextUnusedID = 0;
-	Entity* CreatedEntity = new (MemMgr::Alloc(sizeof(Entity), MemMgr::AllocatorType::PoolData)->addr) Entity(this, NextUnusedID);
+	Entity* CreatedEntity = new (MemMgr::Alloc(sizeof(Entity), MemMgr::AllocatorType::PoolData)) Entity(this, NextUnusedID);
 	++NextUnusedID;
 
 	// Notify systems
@@ -89,19 +89,19 @@ void Engine::AddAllSystems()
 template <class CompType>
 CompType* Engine::AllocateComponent(Entity& entityToAllocateFor)
 {
-	MemoryResource* MemoryForComponent = MemMgr::Alloc(sizeof(CompType), MemMgr::AllocatorType::PoolData);
+	uint8_t* MemoryForComponent = MemMgr::Alloc(sizeof(CompType), MemMgr::AllocatorType::PoolData);
 
 	// Has this component been allocated?	
 	// If so, put it at the back of that type's vector
 	if (CompType::EngineMemoryID < std::numeric_limits<unsigned int>::max())
 	{
-		AllComponents[CompType::EngineMemoryID].push_back(new (MemoryForComponent->addr) CompType());
+		AllComponents[CompType::EngineMemoryID].push_back(new (MemoryForComponent) CompType());
 	}
 	else
 	{
 		// If not, put it at the back of this vector with vector::size()
 		AllComponents.push_back(std::vector<Component*>()); // allocate another row vector for this component type
-		AllComponents[AllComponents.size() - 1].push_back(new (MemoryForComponent->addr) CompType()); // push this component into its new row vector
+		AllComponents[AllComponents.size() - 1].push_back(new (MemoryForComponent) CompType()); // push this component into its new row vector
 		CompType::EngineMemoryID = AllComponents.size() - 1;
 	}
 

--- a/starlight/starlight/core/MemMgr/MemMgr.cpp
+++ b/starlight/starlight/core/MemMgr/MemMgr.cpp
@@ -2,7 +2,8 @@
 #include "Debug.h"
 // Init our MemMgr singleton to null
 std::unique_ptr<MemMgr> MemMgr::memMgr(nullptr);
-
+std::unique_ptr<std::unordered_map<uint8_t*, MemMgr::AllocatorType>> 
+MemMgr::addressToAllocatorMap(new std::unordered_map<uint8_t*, MemMgr::AllocatorType>(500000));
 
 MemMgr::MemMgr(uint totalSpace)
 	: regionSize(totalSpace),
@@ -22,35 +23,35 @@ MemMgr::~MemMgr()
 	delete[] start;
 }
 
-MemoryResource* MemMgr::Alloc(uint resourceSize, MemMgr::AllocatorType type)
+uint8_t* MemMgr::Alloc(uint resourceSize, MemMgr::AllocatorType type)
 {
 	// throw allocation to a specified allocator, depending on the given enum argument
-	MemoryResource* res = reinterpret_cast<MemoryResource*>(memMgr->poolData->Alloc(sizeof(MemoryResource)));
-	res->type = type;
+	uint8_t* addr;
 	switch (type)
 	{
 		case MemMgr::AllocatorType::FrameData:
 		{
-			res->addr = reinterpret_cast<uint8_t*>(memMgr->frameData->Alloc(resourceSize));
+			addr = reinterpret_cast<uint8_t*>(memMgr->frameData->Alloc(resourceSize));
 			break;
 		}
 		case MemMgr::AllocatorType::LevelData:
 		{
-			res->addr = reinterpret_cast<uint8_t*>(memMgr->levelData->Alloc(resourceSize));
+			addr = reinterpret_cast<uint8_t*>(memMgr->levelData->Alloc(resourceSize));
 			break;
 		}
 		case MemMgr::AllocatorType::GlobalData:
 		{
-			res->addr = reinterpret_cast<uint8_t*>(memMgr->globalData->Alloc(resourceSize));
+			addr = reinterpret_cast<uint8_t*>(memMgr->globalData->Alloc(resourceSize));
 			break;
 		}
 		case MemMgr::AllocatorType::PoolData:
 		{
-			res->addr = reinterpret_cast<uint8_t*>(memMgr->poolData->Alloc(resourceSize));
+			addr = reinterpret_cast<uint8_t*>(memMgr->poolData->Alloc(resourceSize));
 			break;
 		}
 	}
-	return res;
+	addressToAllocatorMap->emplace(addr, type);
+	return addr;
 }
 
 void MemMgr::Create(uint totalSpace)
@@ -66,9 +67,9 @@ void MemMgr::Create(uint totalSpace)
 
 }
 
-void MemMgr::Free(MemoryResource* res)
+void MemMgr::Free(uint sz, uint8_t* addr)
 {
-	switch (res->type)
+	switch (addressToAllocatorMap->at(addr))
 	{
 		case MemMgr::AllocatorType::FrameData:
 		case MemMgr::AllocatorType::LevelData:
@@ -76,10 +77,11 @@ void MemMgr::Free(MemoryResource* res)
 			break;
 		case MemMgr::AllocatorType::PoolData:
 		{
-			memMgr->poolData->Free(res->size, res->addr);
+			memMgr->poolData->Free(sz, addr);
 			break;
 		}
 	}
+	addressToAllocatorMap->erase(addr);
 }
 
 uint8_t* MemMgr::AllocSpace(uint totalSpace)

--- a/starlight/starlight/core/MemMgr/MemMgr.h
+++ b/starlight/starlight/core/MemMgr/MemMgr.h
@@ -26,8 +26,6 @@
 	has returned a valid address before attempting to dereference and write into it.
 */
 
-struct MemoryResource;
-
 class MemMgr
 {
 public:
@@ -46,7 +44,7 @@ public:
 	// [out]
 	// Pointer to the first byte of newly allocated memory, or nullptr if resourceSize is too large.
 	// NOTE: You must cast the returned address to the type that you need. See Usage Notes #2 above for more details.
-	static MemoryResource* Alloc(uint resourceSize, AllocatorType type);
+	static uint8_t* Alloc(uint resourceSize, AllocatorType type);
 
 	// Creates a MemMgr instance, default is set to 50 MB
 	static void Create(uint totalSpace = 52450000);
@@ -55,7 +53,7 @@ public:
 	// [in]
 	// resourceSize: Size of allocated resource.
 	// resourceAddr: Address of the first byte of the allocated region, cast to a void*.
-	static void Free(MemoryResource* res);
+	static void Free(uint sz, uint8_t* res);
 
 	~MemMgr();
 
@@ -79,6 +77,8 @@ private:
 	std::unique_ptr<StackAllocator> levelData;
 	std::unique_ptr<PoolAllocator> poolData;
 
+	static std::unique_ptr<std::unordered_map<uint8_t*, MemMgr::AllocatorType>> addressToAllocatorMap;
+
 	// Todo: Add double buffered stack allocator to store frame data
 
 	// total size of the memory manager. Padding of 'largestBlockSize' added
@@ -87,13 +87,6 @@ private:
 
 	// starting address
 	uint8_t* start;
-};
-
-struct MemoryResource
-{
-	uint8_t* addr;
-	MemMgr::AllocatorType type;
-	uint size;
 };
 
 

--- a/starlight/starlight/core/MemMgr/test/MemMgrTestFixture.cpp
+++ b/starlight/starlight/core/MemMgr/test/MemMgrTestFixture.cpp
@@ -1,8 +1,24 @@
 #include "MemMgrTestFixture.h"
-
+#include <cassert>
 void MemMgrTestFixture::RunTests()
 {
 	TestConstructor();
+	TestAlloc();
+}
+
+void MemMgrTestFixture::TestAlloc()
+{
+	MemMgr::Create();
+	int* arr = reinterpret_cast<int*>(MemMgr::Alloc(sizeof(int) * 100, MemMgr::AllocatorType::LevelData));
+	for (int i = 0; i < 100; ++i)
+	{
+		arr[i] = i;
+	}
+	for (int i = 99; i >= 0; --i)
+	{
+		assert(arr[i] == i);
+	}
+	MemMgr::Free(sizeof(int) * 100, reinterpret_cast<uint8_t*>(arr));
 }
 
 void MemMgrTestFixture::TestConstructor()

--- a/starlight/starlight/core/MemMgr/test/MemMgrTestFixture.h
+++ b/starlight/starlight/core/MemMgr/test/MemMgrTestFixture.h
@@ -9,4 +9,6 @@ public:
 
 	void TestConstructor();
 
+	void TestAlloc();
+
 };

--- a/starlight/starlight/starlight.vcxproj
+++ b/starlight/starlight/starlight.vcxproj
@@ -330,6 +330,7 @@
     <ClInclude Include="core\RenderingAPI\src\VertexBufferLayout.h" />
     <ClInclude Include="core\RenderingAPI\src\Window.h" />
     <ClInclude Include="Engine\DamageInRangeSystem.h" />
+    <ClInclude Include="Engine\Engine.h" />
     <ClInclude Include="Engine\HealthComponent.h" />
     <ClInclude Include="tests\Debug.h" />
     <ClInclude Include="core\MemMgr\DoubleBufferAllocator.h" />
@@ -353,7 +354,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="core\FileIO\TextureRequest.cpp" />
-    <ClCompile Include="core\JakeTest.cpp" />
     <ClCompile Include="core\MemMgr\DoubleBufferAllocator.cpp" />
     <ClInclude Include="core\ResourceMgr\Texture.h" />
     <ClInclude Include="core\ResourceMgr\ResourceMgr.h" />
@@ -362,7 +362,6 @@
     <ClInclude Include="Engine\BaseSystem.h" />
     <ClInclude Include="Engine\Component.h" />
     <ClInclude Include="Engine\ECSTypes.h" />
-    <ClInclude Include="Engine\Engine.h" />
     <ClInclude Include="Engine\Entity.h" />
     <ClInclude Include="Engine\MovementSystem.h" />
     <ClInclude Include="Engine\System.h" />
@@ -373,6 +372,7 @@
     <ClCompile Include="core\FileIO\IORequest.cpp" />
     <ClCompile Include="core\math\matrix4.cpp" />
     <ClCompile Include="core\math\vec4.cpp" />
+    <ClCompile Include="core\MemMgr\MemMgrTest.cpp" />
     <ClCompile Include="core\MemMgr\playground.cpp" />
     <ClCompile Include="core\MemMgr\Pool.cpp" />
     <ClCompile Include="core\MemMgr\MemMgr.cpp" />

--- a/starlight/starlight/starlight.vcxproj.filters
+++ b/starlight/starlight/starlight.vcxproj.filters
@@ -28,7 +28,6 @@
     <ClCompile Include="tests\vec3tests.cpp" />
     <ClCompile Include="core\Time\Clock.cpp" />
     <ClCompile Include="Engine\MovementSystem.cpp" />
-    <ClCompile Include="Engine\Engine.cpp" />
     <ClCompile Include="core\RenderingAPI\src\Camera.cpp" />
     <ClCompile Include="core\RenderingAPI\src\IndexBuffer.cpp" />
     <ClCompile Include="core\RenderingAPI\src\Mesh.cpp" />
@@ -54,8 +53,9 @@
     <ClCompile Include="Dependencies\imgui\imgui_impl_opengl3.cpp" />
     <ClCompile Include="Dependencies\imgui\imgui_widgets.cpp" />
     <ClCompile Include="Dependencies\stb_image\stb_image.cpp" />
-    <ClCompile Include="core\JakeTest.cpp" />
     <ClCompile Include="Engine\DamageInRangeSystem.cpp" />
+    <ClCompile Include="core\MemMgr\MemMgrTest.cpp" />
+    <ClCompile Include="Engine\Engine.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="tests\Debug.h" />
@@ -81,7 +81,6 @@
     <ClInclude Include="core\ResourceMgr\ResourceMgr.h" />
     <ClInclude Include="core\ResourceMgr\Resources.h" />
     <ClInclude Include="core\Time\Clock.h" />
-    <ClInclude Include="Engine\Engine.h" />
     <ClInclude Include="Engine\System.h" />
     <ClInclude Include="Engine\MovementSystem.h" />
     <ClInclude Include="Engine\Component.h" />
@@ -401,6 +400,7 @@
     <ClInclude Include="Dependencies\stb_image\stb_image.h" />
     <ClInclude Include="Engine\HealthComponent.h" />
     <ClInclude Include="Engine\DamageInRangeSystem.h" />
+    <ClInclude Include="Engine\Engine.h" />
   </ItemGroup>
   <ItemGroup>
     <Library Include="Dependencies\assimp\lib\assimp-vc140-mt.lib" />


### PR DESCRIPTION
Alloc now returns the raw allocation address instead of a MemoryResource ptr. The type of allocator used for each allocation is now stored inside the MemMgr, so the user will not need to remember.